### PR TITLE
feat: add basic license compatibility validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+licenses
+*.xml
+test.md

--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ in JSON format.
 This is then output to a file based on a template. Default template included in
 the box.
 
+Optionally, using the --validate command line option, this program can make a
+simplistic judgement on whether the licenses of dependencies are compatible with
+the main application license. This is done using the compatibility.yaml source file
+which also lists the relevant disclaimer and reasons for (in)compatibility.
+
 **Note:** this helper program does *not* do any scanning, it just ingests an SBOM.
 
 ## Why?
@@ -15,9 +20,18 @@ file about third-party licenses for another project. Most tools I found were too
 cumbersome, buggy, complex, etc. Since I already had a CycloneDX style SBOM, why
 not re-use...
 
+## Disclaimer
+
+Licensing compatibility can be nuanced, especially for combined or derivative works.
+Always refer to the official license texts, their appendices (if any), and make use of
+additional legal guidance to ensure you’re applying compatibility rules correctly.
+
+This piece of software does its best to be accurrate but gives no guarantees nor
+warranties of any kind.
+
 ## Licensing
 
 This software is made available under the [MPL-2.0](https://choosealicense.com/licenses/mpl-2.0/) license.
 The full details are available from the [LICENSE](/LICENSE) file.
 
-Copyright (C) 2024  Martijn van der Kleijn
+Copyright (C) 2024-2025  Martijn van der Kleijn

--- a/compatibility.yaml
+++ b/compatibility.yaml
@@ -1,0 +1,204 @@
+# -------------------------------------------------------------------------------------
+# This file treats “compatible” to mean:
+#
+#    A given license can be used (inbound / application dependency) and redistributed
+#    (outbound / application) under the main application license without creating
+#    a license conflict.
+#
+# In simpler terms: if you can take (dependency) code under License X, combine it
+# with the main application code, and then distribute the whole under the main
+# application's license, we mark X as compatible (c). If there is a known or likely
+# conflict (or the situation is murky), we mark it as warning (w) or incompatible (i)
+# accordingly.
+#
+# Inbound compatibility: “Can we redistribute this code under the main application license without conflict?”
+#
+# DISCLAIMER: This is NOT legal advice. License interactions can be nuanced.
+#             If you need certainty, consult the official texts and a qualified
+#             lawyer.
+#
+# Format:
+#
+# <main license string>:
+#   <dependency license string>:
+#     status: <c|i|w>
+#     reason: <string>
+# -------------------------------------------------------------------------------------
+
+EUPL-1.2:
+  # -------------------------------------------------------------------------------------
+  # PERMISSIVE LICENSES
+  #
+  # Generally, permissive licenses (MIT, BSD, ISC, etc.) do NOT forbid re-licensing under
+  # a stronger copyleft license like EUPL, so we label them "c" (compatible).
+  #
+  # -------------------------------------------------------------------------------------
+  MIT:
+    status: c
+    reason: "MIT is permissive; code under MIT can be re-licensed under EUPL."
+
+  BSD-2-Clause:
+    status: c
+    reason: "BSD-2-Clause is permissive; inbound re-licensing to EUPL is allowed."
+
+  BSD-3-Clause:
+    status: c
+    reason: "BSD-3-Clause is also permissive; EUPL re-licensing does not conflict."
+
+  BSD-Source-Code:
+    status: c
+    reason: >
+      “BSD-Source-Code” (a.k.a. 4-clause BSD) adds an advertising clause, but
+      it does not forbid relicensing under EUPL. The main requirement is to
+      retain proper attribution in advertising materials.
+
+  0BSD:
+    status: c
+    reason: >
+      0BSD is effectively a public-domain-style license with zero clauses, so
+      there are no restrictions preventing inbound re-licensing under EUPL-1.2.
+
+  ISC:
+    status: c
+    reason: "ISC is a very permissive license, so EUPL re-licensing is fine."
+
+  Apache-2.0:
+    status: c
+    reason: >
+      Although there's complexity around patent clauses, EUPL 1.2 is generally
+      interpreted as GPLv3-compatible, and Apache-2.0 is compatible with GPLv3.
+      Therefore, inbound re-licensing to EUPL is typically not prohibited.
+
+  # -------------------------------------------------------------------------------------
+  # GNU LICENSES
+  #
+  # Some of these are explicitly mentioned as "compatible" in the EUPL Appendix for
+  # outbound re-licensing from EUPL to GPL. Inbound direction can be trickier,
+  # especially for GPL v2 "only" vs. "or later."
+  # -------------------------------------------------------------------------------------
+
+  # GPL v2 (only)
+  GPL-2.0-only:
+    status: w
+    reason: >
+      If GPL-2.0 code lacks the "or later" clause, re-licensing to EUPL may be murky.
+      Some argue EUPL's terms can conflict with strict GPL-2.0. Review on case-by-case basis.
+
+  # GPL v2 (or later)
+  GPL-2.0-or-later:
+    status: c
+    reason: >
+      Code under GPL-2.0+ can generally be upgraded to GPL-3.0 or a GPL-3.0-compatible license.
+      EUPL 1.2 is often treated as GPL-3.0-compatible, so inbound is acceptable.
+
+  # GPL v3 (only)
+  GPL-3.0-only:
+    status: c
+    reason: >
+      EUPL is considered broadly compatible with GPL v3. You can typically
+      integrate GPL-3.0 code and release under EUPL (though do verify text overlap carefully).
+
+  # AGPL v3 (only)
+  AGPL-3.0-only:
+    status: c
+    reason: >
+      The EUPL Appendix lists AGPL-3.0 as outward-compatible, and inbound re-licensing to EUPL
+      generally doesn't conflict because AGPL v3 terms are not stricter than EUPL.
+
+  # LGPL 2.1 (only)
+  LGPL-2.1-only:
+    status: w
+    reason: >
+      This can be tricky, because LGPL-2.1 has some linking exceptions and no "or later" text by default.
+      Often, you can relicense if there's an explicit "or later" clause. Otherwise, check carefully.
+
+  # LGPL 2.1 (or later)
+  LGPL-2.1-or-later:
+    status: c
+    reason: >
+      Adding "or later" typically lets you upgrade to LGPL-3.0 or a GPL-3.0-compatible license,
+      which EUPL broadly is. Usually this is safe inbound.
+
+  # LGPL 3.0 (only)
+  LGPL-3.0-only:
+    status: c
+    reason: "LGPL 3.0 is effectively a subset of GPL v3 terms, so inbound re-licensing to EUPL is allowed."
+
+  # -------------------------------------------------------------------------------------
+  # ECLIPSE PUBLIC LICENSES
+  # -------------------------------------------------------------------------------------
+  EPL-1.0:
+    status: w
+    reason: >
+      The older EPL-1.0 is not in the official EUPL “compatible licenses” list.
+      Some say inbound re-licensing is possible with extra disclaimers, but there are nuances.
+
+  EPL-2.0:
+    status: c
+    reason: >
+      EUPL 1.2 includes EPL-2.0 in its Appendix (for outbound),
+      and inbound direction is generally not contradictory.
+
+  # -------------------------------------------------------------------------------------
+  # MOZILLA PUBLIC LICENSE
+  # -------------------------------------------------------------------------------------
+  MPL-1.1:
+    status: w
+    reason: >
+      MPL-1.1 can be tricky to combine with other copyleft licenses. It's not in EUPL's
+      official list. Often replaced by MPL-2.0. Review carefully.
+
+  MPL-2.0:
+    status: c
+    reason: >
+      EUPL 1.2 includes MPL-2.0 in its Appendix for outbound re-licensing,
+      which generally implies inbound is acceptable.
+
+  # -------------------------------------------------------------------------------------
+  # CeCILL LICENSES
+  # -------------------------------------------------------------------------------------
+  CeCILL-2.0:
+    status: c
+    reason: >
+      EUPL 1.2 explicitly lists CeCILL v2.0 as an outbound-compatible license.
+      Typically no conflict inbound.
+
+  CeCILL-2.1:
+    status: c
+    reason: >
+      EUPL 1.2 likewise lists CeCILL v2.1 as compatible. Inbound re-licensing to EUPL is fine.
+
+  # -------------------------------------------------------------------------------------
+  # OPEN SOFTWARE LICENSES
+  # -------------------------------------------------------------------------------------
+  OSL-2.1:
+    status: c
+    reason: >
+      EUPL 1.2 references OSL in its Appendix. Inbound re-licensing is not prohibited.
+
+  OSL-3.0:
+    status: c
+    reason: >
+      OSL-3.0 is also in the EUPL Appendix for outbound. Generally considered inbound-compatible.
+
+  # -------------------------------------------------------------------------------------
+  # OTHER COMMON LICENSES
+  # (Mark them as "c", "w", or "i" based on known or likely conflicts)
+  # -------------------------------------------------------------------------------------
+  CDDL-1.0:
+    status: w
+    reason: >
+      Combining CDDL code with copyleft licenses can lead to "dual-licensing"
+      complexity (not in EUPL’s official list). Evaluate on a case-by-case basis.
+
+  SSPL-1.0:
+    status: i
+    reason: >
+      SSPL has unique requirements that are not generally seen as compatible
+      with standard free/open licenses, including EUPL.
+
+# -------------------------------------------------------------------------------------
+# You can add or remove entries as needed. For any license not shown, make
+# a judgement call: "c", "w", or "i" depending on whether it can be inbound-relicensed
+# to the main license without conflicts.
+# -------------------------------------------------------------------------------------

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/mvdkleijn/licenses
 
 go 1.22.4
+
+require gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 /*
 	License - generates a human-readable file about third-party licenses
-	Copyright (C) 2024  Martijn van der Kleijn
+	Copyright (C) 2024-2025  Martijn van der Kleijn
 
 	This Source Code Form is subject to the terms of the Mozilla Public
 	License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -20,7 +20,18 @@ import (
 	"os"
 	"sort"
 	"text/template"
+
+	"gopkg.in/yaml.v3"
 )
+
+// LicenseStatus holds the status (c/i/w) and optionally a reason.
+type LicenseStatus struct {
+	Status string `yaml:"status"`
+	Reason string `yaml:"reason,omitempty"`
+}
+
+// Compatibility is a nested map for license compatibility lookup.
+type Compatibility map[string]map[string]LicenseStatus
 
 // Component represents the structure of a component in the input.
 type Component struct {
@@ -33,9 +44,44 @@ type Component struct {
 	} `json:"licenses" xml:"licenses"`
 }
 
+// LoadCompatibility reads the YAML file at the given path and unmarshals it
+// into the Compatibility structure.
+func LoadCompatibility(filePath string) (Compatibility, error) {
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file %q: %w", filePath, err)
+	}
+
+	var comp Compatibility
+	if err := yaml.Unmarshal(data, &comp); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal YAML: %w", err)
+	}
+
+	return comp, nil
+}
+
+// GetLicenseStatus looks up a main license and sub license in the Compatibility map.
+// It returns the status (c/i/w), the optional reason, or an error if not found.
+func GetLicenseStatus(comp Compatibility, mainLicense, subLicense string) (string, string, error) {
+	// Check if the main license is in the map
+	subMap, ok := comp[mainLicense]
+	if !ok {
+		return "", "", fmt.Errorf("no entry for main license: %s", mainLicense)
+	}
+
+	// Check if the sub license is in the sub-map
+	ls, ok := subMap[subLicense]
+	if !ok {
+		return "", "", fmt.Errorf("no sub license: %s for main license: %s", subLicense, mainLicense)
+	}
+
+	return ls.Status, ls.Reason, nil
+}
+
 // BOM represents the overall structure of the input.
 type BOM struct {
 	XMLName    xml.Name    `xml:"bom"` // Matches the root element, e.g., <bom>
+	Metadata   Component   `json:"metadata" xml:"metadata>component"`
 	Components []Component `json:"components" xml:"components>component"`
 }
 
@@ -97,16 +143,28 @@ func main() {
 	outputFileFlag := flag.String("o", "./licenses.md", "Output file.")
 	formatFlag := flag.String("f", "json", "Input format (json or xml)")
 	templateFileFlag := flag.String("t", "./template.txt", "Golang template file to use for output.")
+	validateLicenses := flag.Bool("validate", false, "Validate that dependency's licenses are compatible with the main license.")
 	flag.Parse()
 
 	var bom BOM
-
+	var comp Compatibility
 	var err error
+
+	if *validateLicenses {
+		comp, err = LoadCompatibility("compatibility.yaml")
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
 
 	bom, err = parse(*inputFileFlag, *formatFlag)
 	if err != nil {
 		log.Fatalf("Error parsing file: %v", err)
 	}
+
+	// Retrieve main application license
+	applicationLicense := bom.Metadata.Licenses[len(bom.Metadata.Licenses)-1]
+	compissues := make(map[string]LicenseStatus)
 
 	if len(bom.Components) == 0 {
 		log.Fatalf("unknown structure or empty components in sbom")
@@ -118,6 +176,20 @@ func main() {
 		licenseID := "No License"
 		if len(component.Licenses) > 0 {
 			licenseID = component.Licenses[0].License.ID
+			if *validateLicenses {
+				status, reason, err := GetLicenseStatus(comp, applicationLicense.License.ID, licenseID)
+				if err != nil {
+					compissues[component.Licenses[0].License.ID] = LicenseStatus{
+						Status: "error",
+						Reason: "ERROR - License not found in compatibility matrix.",
+					}
+				} else if status == "w" || status == "i" {
+					compissues[component.Licenses[0].License.ID] = LicenseStatus{
+						Status: status,
+						Reason: reason,
+					}
+				}
+			}
 		}
 		componentsByLicense[licenseID] = append(componentsByLicense[licenseID], component)
 	}
@@ -153,4 +225,17 @@ func main() {
 	}
 
 	fmt.Printf("Components information has been written to %s\n", *outputFileFlag)
+
+	// If there are any issues, exit with non-zero status
+	if *validateLicenses && len(compissues) > 0 {
+		fmt.Println("Found license compatibility issues:")
+		for key, issue := range compissues {
+			fmt.Printf("- %s: %s)\n", key, issue.Reason)
+		}
+		os.Exit(1) // Non-zero exit code for build pipeline
+	}
+
+	// Otherwise, exit normally
+	fmt.Println("No issues found.")
+	os.Exit(0)
 }


### PR DESCRIPTION
This adds very basic license compatibility checks, based on a yaml file marking whether or not a (sub)license is compatible with another (main)license.

The yaml file might grows a lot in the future so perhaps another option is needed then. For now however, this offers a lot of flexibility IMHO.